### PR TITLE
Added getUpdates engine for Telegram API.

### DIFF
--- a/.idea/team2_qgame.iml
+++ b/.idea/team2_qgame.iml
@@ -2,6 +2,7 @@
 <module type="WEB_MODULE" version="4">
   <component name="Go" enabled="true" />
   <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$/../gotg" />
     <content url="file://$MODULE_DIR$" />
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/api/bot.go
+++ b/api/bot.go
@@ -1,1 +1,38 @@
 package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+type Client struct {
+	token string
+}
+
+func (c *Client) SetToken(token string) error {
+	c.token = token
+
+	query := fmt.Sprintf("https://api.telegram.org/bot%s/getMe", token)
+
+	resp, err := http.Get(query)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	bytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	response := Response{}
+	err = json.Unmarshal(bytes, &response)
+
+	if response.OK {
+		return nil
+	}
+	return errors.New(string(bytes))
+}

--- a/api/bot_test.go
+++ b/api/bot_test.go
@@ -1,0 +1,33 @@
+package api
+
+import "testing"
+
+func TestClient_SetToken(t *testing.T) {
+	type args struct {
+		token string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			"NormalTest",
+			args{"1285255270:SomeCorrectToken"},
+			false,
+		},
+		{
+			"ErrorTest",
+			args{"1285234123:SomeIncorrectToken"},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c Client
+			if err := c.SetToken(tt.args.token); (err != nil) != tt.wantErr {
+				t.Errorf("SetToken() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/api/getUpdates.go
+++ b/api/getUpdates.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+func (c *Client) GetUpdates(offset int) []Update{
+	var response Response
+
+	req := url.Values{}
+	req.Add("offset", strconv.Itoa(offset))
+
+	query := fmt.Sprintf("https://api.telegram.org/bot%s/getUpdates?", c.token) + req.Encode()
+	resp, err := http.Get(query)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return response.Result
+}

--- a/api/getUpdates_test.go
+++ b/api/getUpdates_test.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+)
+
+// Uses a different testing method as the input&output are usually different
+func TestClient_GetUpdates(t *testing.T) {
+	firstUpdate := 0
+	lastUpdate := 0
+
+	client := &Client{
+		"1285255270:AAFdQW1_ygN6CxQU8DzRBHLS3YLaKswLdqY",
+	}
+
+	// terminates after receiving 10 updates
+	for lastUpdate-firstUpdate < 10{
+		updates := client.GetUpdates(lastUpdate+1)
+		if len(updates) != 0{
+			fmt.Println(updates[0])
+
+			if firstUpdate == 0{
+				firstUpdate = updates[0].UpdateID
+			}
+			lastUpdate = updates[0].UpdateID
+		}
+	}
+}

--- a/api/response.go
+++ b/api/response.go
@@ -1,0 +1,10 @@
+package api
+
+type Response struct {
+	OK bool `json:"ok"`
+
+	Result []Update `json:"result"`
+
+	ErrorCode int `json:"error_code"`
+	Description string `json:"description"`
+}

--- a/api/update.go
+++ b/api/update.go
@@ -1,0 +1,6 @@
+package api
+
+type Update struct{
+	UpdateID int `json:"update_id"`
+	Message UpdateMessage
+}

--- a/api/updateMessage.go
+++ b/api/updateMessage.go
@@ -1,0 +1,8 @@
+package api
+
+type UpdateMessage struct {
+	MessageID int `json:"message_id"`
+	User User `json:"from"`
+	Date int64 `json:"date"`
+	Text string `json:"text"`
+}

--- a/api/user.go
+++ b/api/user.go
@@ -1,0 +1,9 @@
+package api
+
+type User struct {
+	ID int `json:"id"`
+	IsBot bool `json:"is_bot"`
+	FirstName string `json:"first_name"`
+	Username string `json:"username"`
+	LangCode string `json:"language_code"`
+}


### PR DESCRIPTION
Set up `getUpdates()` engine that could be implemented as long polling for handling updates. Usage is shown in test file for the function.